### PR TITLE
client_config add apollo config

### DIFF
--- a/client/config/client_config.go
+++ b/client/config/client_config.go
@@ -13,6 +13,7 @@ import (
 
 import (
 	"github.com/dk-lockdown/seata-golang/client/at/sql/schema/cache"
+	"github.com/shima-park/agollo"
 )
 
 type ClientConfig struct {

--- a/client/config/client_config.go
+++ b/client/config/client_config.go
@@ -81,3 +81,30 @@ func InitConfWithDefault(applicationId string) {
 	clientConfig = GetDefaultClientConfig(applicationId)
 	(&clientConfig).GettyConfig.CheckValidity()
 }
+
+func InitEtcdConf(serverAddr string, appId string, nameSpace string) error {
+
+	a, err := agollo.New(serverAddr, appId, agollo.AutoFetchOnCacheMiss())
+	if err != nil {
+		return errors.WithMessagef(err, fmt.Sprintf("get etcd error:%s", err))
+	}
+
+	var config = a.Get("content", agollo.WithNamespace(nameSpace))
+	return initCommonConf([]byte(config))
+}
+func initCommonConf(confStream []byte) error {
+	var err error
+	err = yaml.Unmarshal(confStream, &clientConfig)
+	fmt.Println("config", clientConfig)
+	if err != nil {
+		return errors.WithMessagef(err, fmt.Sprintf("yaml.Unmarshal() = error:%s", err))
+	}
+
+	(&clientConfig).GettyConfig.CheckValidity()
+	(&clientConfig).ATConfig.CheckValidity()
+
+	if clientConfig.ATConfig.DSN != "" {
+		cache.SetTableMetaCache(cache.NewMysqlTableMetaCache(clientConfig.ATConfig.DSN))
+	}
+	return nil
+}

--- a/client/config/client_config.go
+++ b/client/config/client_config.go
@@ -83,7 +83,7 @@ func InitConfWithDefault(applicationId string) {
 	(&clientConfig).GettyConfig.CheckValidity()
 }
 
-func InitEtcdConf(serverAddr string, appId string, nameSpace string) error {
+func InitApolloConf(serverAddr string, appId string, nameSpace string) error {
 
 	a, err := agollo.New(serverAddr, appId, agollo.AutoFetchOnCacheMiss())
 	if err != nil {


### PR DESCRIPTION
### Ⅰ. Describe what this PR did

client_config init add apollo config
example:	seata-golang/client/config.InitEtcdConf("172.20.0.11:8080", "seata", "seata.yml")

### Ⅱ. Does this pull request fix one issue?

apollo config


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews